### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This will create a python virtual environment in the code directory for you to u
 
 ### Mac/Linux
 ```sh
-source ./myenv/bin/activate
+source ./myvenv/bin/activate
 ```
 
 ### Windows


### PR DESCRIPTION
Fixed a small typo in the README file regarding the virtual environment setup instructions for Mac/Linux.